### PR TITLE
Save user information on anonymous posts for server side use

### DIFF
--- a/public/js/create_post.js
+++ b/public/js/create_post.js
@@ -66,21 +66,37 @@ function submitPost() {
     UID = firebase.auth().currentUser.uid;
     // if user chose to post anonymously or isn't signed in, post anonymously
     let anon = $("input[name='anonymous']:checked").val();
-    if (anon || !UID) {
-        addPost(
-            true,
-            auth=null,
-            uid=UID,
-            title=titleField.value,
-            body=bodyField.value,
-            subject=topic
-        );
+    if (anon) {
+        //If there is not a logged in user, do not save username and uid in database
+        if (!UID) {
+            addPost(
+                anonymous=true,
+                auth=null,
+                uid=null,
+                title=titleField.value,
+                body=bodyField.value,
+                subject=topic
+            );
+        }
+        //If there is someone logged in, save a username and uid in database
+        else {
+            db.collection('users').doc(UID).get().then(user => {
+                addPost(
+                    anonymous=true,
+                    auth=user.data().username,
+                    uid=UID,
+                    title=titleField.value,
+                    body=bodyField.value,
+                    subject=topic
+                );
+            });
+        }
     }
     // otherwise post with username attached
     else {
         db.collection('users').doc(UID).get().then(user => {
             addPost(
-                false,
+                anonymous=false,
                 auth=user.data().username,
                 uid=UID,
                 title=titleField.value,

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -19,10 +19,11 @@ function renderPost(doc){
   } 
   title.textContent = doc.data().title;
   content.textContent = doc.data().content;
-  if (doc.data().author != null) {
-    author.textContent = "author: " + doc.data().author;
-  } else {
+  //Check anon flag
+  if (doc.data().anon == true) {
     author.textContent = "[anonymous]"
+  } else {
+    author.textContent = "author: " + doc.data().author;
   }
   created.textContent = doc.data().created.toDate();
   img.setAttribute('src', doc.data().image);


### PR DESCRIPTION
To go into more detail, each post now has an anonymous flag. If a user is logged in and chooses to post anonymously, the database will now save their username and UID and set the anonymous flag to 'true'. This way, users can now see the anonymous posts they make on their own userlines.